### PR TITLE
Make booleans pointers

### DIFF
--- a/common/functions.go
+++ b/common/functions.go
@@ -1,0 +1,5 @@
+package common
+
+func Bool(b bool) *bool {
+	return &b
+}

--- a/common/models.go
+++ b/common/models.go
@@ -46,7 +46,3 @@ type Scope struct {
 	Id string `json:"id,omitempty"`
 	Type string `json:"type,omitempty"`
 }
-
-func Bool(b bool) *bool {
-	return &b
-}

--- a/project/project.go
+++ b/project/project.go
@@ -21,14 +21,14 @@ type Project struct {
 }
 
 type AdvanceSettings struct {
-	AutocancelBuilds           bool     `json:"autocancel_builds,omitempty"`
-	BuildForkPrs               bool     `json:"build_fork_prs,omitempty"`
-	DisableSSH                 bool     `json:"disable_ssh,omitempty"`
-	ForksReceiveSecretEnvVars  bool     `json:"forks_receive_secret_env_vars,omitempty"`
-	OSS                        bool     `json:"oss,omitempty"`
-	SetGithubStatus            bool     `json:"set_github_status,omitempty"`
-	SetupWorkflows             bool     `json:"setup_workflows,omitempty"`
-	WriteSettingsRequiresAdmin bool     `json:"write_settings_requires_admin,omitempty"`
+	AutocancelBuilds           *bool     `json:"autocancel_builds,omitempty"`
+	BuildForkPrs               *bool     `json:"build_fork_prs,omitempty"`
+	DisableSSH                 *bool     `json:"disable_ssh,omitempty"`
+	ForksReceiveSecretEnvVars  *bool     `json:"forks_receive_secret_env_vars,omitempty"`
+	OSS                        *bool     `json:"oss,omitempty"`
+	SetGithubStatus            *bool     `json:"set_github_status,omitempty"`
+	SetupWorkflows             *bool     `json:"setup_workflows,omitempty"`
+	WriteSettingsRequiresAdmin *bool     `json:"write_settings_requires_admin,omitempty"`
 	PROnlyBranchOverrides      []string `json:"pr_only_branch_overrides,omitempty"`
 }
 

--- a/tests/project_test.go
+++ b/tests/project_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/CircleCI-Public/circleci-sdk-go/client"
+	"github.com/CircleCI-Public/circleci-sdk-go/common"
 	"github.com/CircleCI-Public/circleci-sdk-go/project"
 )
 
@@ -56,8 +57,8 @@ func TestFullProject(t *testing.T) {
 	t.Log(project_settings)
 	new_settings := project.ProjectSettings{
 		Advanced: project.AdvanceSettings{
-			AutocancelBuilds: true,
-			DisableSSH: false,
+			AutocancelBuilds: common.Bool(true),
+			DisableSSH: common.Bool(false),
 		},
 	}
 	project_settings, err = projectService.UpdateSettings(new_settings, "circleci", p.OrganizationId, p.Id)


### PR DESCRIPTION
Resolves #12 

This should solve the linked issue by making the booleans pointers. Any usage of the struct will need to change to use a pointer. To facilitate this, the common package provides a Bool function that returns the pointer of a boolean.