### PR TITLE
Include JSON response decoding in client

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -24,7 +24,7 @@ func NewClient(baseURL, authToken string) *Client {
 	}
 }
 
-func requestHelperFunction(url, token, method string, body any, client *http.Client) (res *http.Response, err error) {
+func requestHelperFunction(url, token, method string, body, respBody any, client *http.Client) (_ *Response, err error) {
 	var reqBody io.Reader
 	if body != nil {
 		jsonData, err := json.Marshal(body)
@@ -41,27 +41,45 @@ func requestHelperFunction(url, token, method string, body any, client *http.Cli
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Circle-Token", token)
 
-	res, err = client.Do(req)
+	res, err := client.Do(req)
 	if err != nil {
 		return nil, err
 	}
 
+	defer closer.ErrorHandler(res.Body, &err)
+	defer func() {
+		// This helps with connection pooling (makes sure there's nothing trailing in the HTTP request like newlines)
+		_, _ = io.Copy(io.Discard, res.Body)
+	}()
+
 	if res.StatusCode >= 400 {
-		defer closer.ErrorHandler(res.Body, &err)
 		body, err := io.ReadAll(res.Body)
 		if err != nil {
 			return nil, fmt.Errorf("error Reading response: %w", err)
 		}
 		return nil, fmt.Errorf("%s: %s", res.Status, string(body))
 	}
-	return res, nil
+
+	if respBody != nil {
+		if err := json.NewDecoder(res.Body).Decode(respBody); err != nil {
+			return nil, err
+		}
+	}
+
+	return &Response{
+		StatusCode: res.StatusCode,
+	}, nil
+}
+
+type Response struct {
+	StatusCode int
 }
 
 // RequestHelperAbsolute is the same as RequestHelper but allows to do a request to other APIs
-func (c *Client) RequestHelperAbsolute(method, path string, body any) (*http.Response, error) {
-	return requestHelperFunction(path, c.AuthToken, method, body, c.HTTPClient)
+func (c *Client) RequestHelperAbsolute(method, path string, body, respBody any) (*Response, error) {
+	return requestHelperFunction(path, c.AuthToken, method, body, respBody, c.HTTPClient)
 }
 
-func (c *Client) RequestHelper(method, path string, body any) (*http.Response, error) {
-	return requestHelperFunction(c.BaseURL+path, c.AuthToken, method, body, c.HTTPClient)
+func (c *Client) RequestHelper(method, path string, reqBody, respBody any) (*Response, error) {
+	return requestHelperFunction(c.BaseURL+path, c.AuthToken, method, reqBody, respBody, c.HTTPClient)
 }

--- a/env/env.go
+++ b/env/env.go
@@ -1,13 +1,11 @@
 package env
 
 import (
-	"encoding/json"
 	"fmt"
 	"net/http"
 
 	"github.com/CircleCI-Public/circleci-sdk-go/client"
 	"github.com/CircleCI-Public/circleci-sdk-go/common"
-	"github.com/CircleCI-Public/circleci-sdk-go/internal/closer"
 )
 
 //nolint:revive
@@ -31,16 +29,12 @@ func (s *EnvService) List(contextID string) (_ []EnvVariable, err error) {
 	var nextPageToken string
 	var contextList []EnvVariable
 	for {
-		res, err := s.client.RequestHelper(http.MethodGet, fmt.Sprintf("/context/%s/environment-variable?page-token=%s", contextID, nextPageToken), nil)
+		var response common.PaginatedResponse[EnvVariable]
+		_, err = s.client.RequestHelper(http.MethodGet, fmt.Sprintf("/context/%s/environment-variable?page-token=%s", contextID, nextPageToken), nil, &response)
 		if err != nil {
 			return nil, err
 		}
-		defer closer.ErrorHandler(res.Body, &err)
 
-		var response common.PaginatedResponse[EnvVariable]
-		if err := json.NewDecoder(res.Body).Decode(&response); err != nil {
-			return nil, err
-		}
 		contextList = append(contextList, response.Items...)
 		if response.NextPageToken == "" {
 			break
@@ -54,25 +48,15 @@ func (s *EnvService) Create(contextID, value, name string) (_ *EnvVariable, err 
 	payload := map[string]string{
 		"value": value,
 	}
-	res, err := s.client.RequestHelper(http.MethodPut, fmt.Sprintf("/context/%s/environment-variable/%s", contextID, name), payload)
-	if err != nil {
-		return nil, err
-	}
-	defer closer.ErrorHandler(res.Body, &err)
-
 	var envVariable EnvVariable
-	if err := json.NewDecoder(res.Body).Decode(&envVariable); err != nil {
+	_, err = s.client.RequestHelper(http.MethodPut, fmt.Sprintf("/context/%s/environment-variable/%s", contextID, name), payload, &envVariable)
+	if err != nil {
 		return nil, err
 	}
 	return &envVariable, nil
 }
 
 func (s *EnvService) Delete(contextID, name string) (err error) {
-	res, err := s.client.RequestHelper(http.MethodDelete, fmt.Sprintf("/context/%s/environment-variable/%s", contextID, name), nil)
-	if err != nil {
-		return err
-	}
-	defer closer.ErrorHandler(res.Body, &err)
-
-	return nil
+	_, err = s.client.RequestHelper(http.MethodDelete, fmt.Sprintf("/context/%s/environment-variable/%s", contextID, name), nil, nil)
+	return err
 }

--- a/organization/org.go
+++ b/organization/org.go
@@ -1,11 +1,9 @@
 package organization
 
 import (
-	"encoding/json"
 	"net/http"
 
 	"github.com/CircleCI-Public/circleci-sdk-go/client"
-	"github.com/CircleCI-Public/circleci-sdk-go/internal/closer"
 )
 
 type Organization struct {
@@ -26,28 +24,18 @@ func NewOrganizationService(c *client.Client) *OrganizationService {
 }
 
 func (s *OrganizationService) Create(name, vcsType string) (org *Organization, err error) {
-	res, err := s.client.RequestHelper(http.MethodPost, "/organization", Organization{
+	org = &Organization{}
+	_, err = s.client.RequestHelper(http.MethodPost, "/organization", Organization{
 		Name:    name,
 		VcsType: vcsType,
-	})
+	}, org)
 	if err != nil {
-		return nil, err
-	}
-	defer closer.ErrorHandler(res.Body, &err)
-
-	org = &Organization{}
-	if err := json.NewDecoder(res.Body).Decode(org); err != nil {
 		return nil, err
 	}
 	return org, nil
 }
 
 func (s *OrganizationService) Delete(orgID string) (err error) {
-	res, err := s.client.RequestHelper(http.MethodDelete, "/organization/"+orgID, nil)
-	if err != nil {
-		return err
-	}
-	defer closer.ErrorHandler(res.Body, &err)
-
-	return nil
+	_, err = s.client.RequestHelper(http.MethodDelete, "/organization/"+orgID, nil, nil)
+	return err
 }

--- a/pipeline/pipeline.go
+++ b/pipeline/pipeline.go
@@ -1,13 +1,11 @@
 package pipeline
 
 import (
-	"encoding/json"
 	"fmt"
 	"net/http"
 
 	"github.com/CircleCI-Public/circleci-sdk-go/client"
 	"github.com/CircleCI-Public/circleci-sdk-go/common"
-	"github.com/CircleCI-Public/circleci-sdk-go/internal/closer"
 )
 
 type Pipeline struct {
@@ -34,69 +32,49 @@ func NewPipelineService(c *client.Client) *PipelineService {
 }
 
 func (s *PipelineService) Get(projectID, pipelineID string) (_ *Pipeline, err error) {
-	res, err := s.client.RequestHelper(http.MethodGet, fmt.Sprintf("/projects/%s/pipeline-definitions/%s", projectID, pipelineID), nil)
+	var pipeline Pipeline
+	_, err = s.client.RequestHelper(http.MethodGet, fmt.Sprintf("/projects/%s/pipeline-definitions/%s", projectID, pipelineID), nil, &pipeline)
 	if err != nil {
 		return nil, err
 	}
-	defer closer.ErrorHandler(res.Body, &err)
 
-	var pipeline Pipeline
-	if err := json.NewDecoder(res.Body).Decode(&pipeline); err != nil {
-		return nil, err
-	}
 	return &pipeline, nil
 }
 
 func (s *PipelineService) List(projectID string) (_ []Pipeline, err error) {
-	res, err := s.client.RequestHelper(http.MethodGet, fmt.Sprintf("/projects/%s/pipeline-definitions", projectID), nil)
+	var pipelineItems PipelineItems
+	_, err = s.client.RequestHelper(http.MethodGet, fmt.Sprintf("/projects/%s/pipeline-definitions", projectID), nil, &pipelineItems)
 	if err != nil {
 		return nil, err
 	}
-	defer closer.ErrorHandler(res.Body, &err)
 
-	var pipelineItems PipelineItems
-	if err := json.NewDecoder(res.Body).Decode(&pipelineItems); err != nil {
-		return nil, err
-	}
 	return pipelineItems.Items, nil
 }
 
 func (s *PipelineService) Create(newPipeline Pipeline, projectID string) (_ *Pipeline, err error) {
-	res, err := s.client.RequestHelper(http.MethodPost, fmt.Sprintf("/projects/%s/pipeline-definitions", projectID), newPipeline)
+	var pipeline Pipeline
+	_, err = s.client.RequestHelper(http.MethodPost, fmt.Sprintf("/projects/%s/pipeline-definitions", projectID), newPipeline, &pipeline)
 	if err != nil {
 		return nil, err
 	}
-	defer closer.ErrorHandler(res.Body, &err)
 
-	var pipeline Pipeline
-	if err := json.NewDecoder(res.Body).Decode(&pipeline); err != nil {
-		return nil, err
-	}
 	return &pipeline, nil
 }
 
 func (s *PipelineService) Delete(projectID, pipelineID string) (err error) {
-	res, err := s.client.RequestHelper(http.MethodDelete, fmt.Sprintf("/projects/%s/pipeline-definitions/%s", projectID, pipelineID), nil)
-	if err != nil {
-		return err
-	}
-	defer closer.ErrorHandler(res.Body, &err)
-
-	return nil
+	_, err = s.client.RequestHelper(http.MethodDelete, fmt.Sprintf("/projects/%s/pipeline-definitions/%s", projectID, pipelineID), nil, nil)
+	return err
 }
 
 // Update - The new pipeline param can only have the eseential values:
 // name, description, config_source.file_path, checkout_source.provider, checkout_source.repo.external_id
 // This are the only values that can be updated with this method, and the objet passed can only have these defined
 func (s *PipelineService) Update(newPipeline Pipeline, projectID, pipelineID string) (_ *Pipeline, err error) {
-	res, err := s.client.RequestHelper(http.MethodPatch, fmt.Sprintf("/projects/%s/pipeline-definitions/%s", projectID, pipelineID), newPipeline)
+	var pipeline Pipeline
+	_, err = s.client.RequestHelper(http.MethodPatch, fmt.Sprintf("/projects/%s/pipeline-definitions/%s", projectID, pipelineID), newPipeline, &pipeline)
 	if err != nil {
 		return nil, err
 	}
-	defer closer.ErrorHandler(res.Body, &err)
-	var pipeline Pipeline
-	if err := json.NewDecoder(res.Body).Decode(&pipeline); err != nil {
-		return nil, err
-	}
+
 	return &pipeline, nil
 }

--- a/trigger/trigger.go
+++ b/trigger/trigger.go
@@ -1,13 +1,11 @@
 package trigger
 
 import (
-	"encoding/json"
 	"fmt"
 	"net/http"
 
 	"github.com/CircleCI-Public/circleci-sdk-go/client"
 	"github.com/CircleCI-Public/circleci-sdk-go/common"
-	"github.com/CircleCI-Public/circleci-sdk-go/internal/closer"
 )
 
 type Trigger struct {
@@ -37,69 +35,49 @@ func NewTriggerService(c *client.Client) *TriggerService {
 }
 
 func (s *TriggerService) Get(projectID, triggerID string) (_ *Trigger, err error) {
-	res, err := s.client.RequestHelper(http.MethodGet, fmt.Sprintf("/projects/%s/triggers/%s", projectID, triggerID), nil)
+	var trigger Trigger
+	_, err = s.client.RequestHelper(http.MethodGet, fmt.Sprintf("/projects/%s/triggers/%s", projectID, triggerID), nil, &trigger)
 	if err != nil {
 		return nil, err
 	}
-	defer closer.ErrorHandler(res.Body, &err)
 
-	var trigger Trigger
-	if err := json.NewDecoder(res.Body).Decode(&trigger); err != nil {
-		return nil, err
-	}
 	return &trigger, nil
 }
 
 func (s *TriggerService) List(projectID, pipelineID string) (_ []Trigger, err error) {
-	res, err := s.client.RequestHelper(http.MethodGet, fmt.Sprintf("/projects/%s/pipeline-definitions/%s/triggers", projectID, pipelineID), nil)
+	var triggerItems TriggerItems
+	_, err = s.client.RequestHelper(http.MethodGet, fmt.Sprintf("/projects/%s/pipeline-definitions/%s/triggers", projectID, pipelineID), nil, &triggerItems)
 	if err != nil {
 		return nil, err
 	}
-	defer closer.ErrorHandler(res.Body, &err)
 
-	var triggerItems TriggerItems
-	if err := json.NewDecoder(res.Body).Decode(&triggerItems); err != nil {
-		return nil, err
-	}
 	return triggerItems.Items, nil
 }
 
 func (s *TriggerService) Create(newTrigger Trigger, projectID, pipelineID string) (_ *Trigger, err error) {
-	res, err := s.client.RequestHelper(http.MethodPost, fmt.Sprintf("/projects/%s/pipeline-definitions/%s/triggers", projectID, pipelineID), newTrigger)
+	var trigger Trigger
+	_, err = s.client.RequestHelper(http.MethodPost, fmt.Sprintf("/projects/%s/pipeline-definitions/%s/triggers", projectID, pipelineID), newTrigger, &trigger)
 	if err != nil {
 		return nil, err
 	}
-	defer closer.ErrorHandler(res.Body, &err)
 
-	var trigger Trigger
-	if err := json.NewDecoder(res.Body).Decode(&trigger); err != nil {
-		return nil, err
-	}
 	return &trigger, nil
 }
 
 func (s *TriggerService) Delete(projectID, triggerID string) (err error) {
-	res, err := s.client.RequestHelper(http.MethodDelete, fmt.Sprintf("/projects/%s/triggers/%s", projectID, triggerID), nil)
-	if err != nil {
-		return err
-	}
-	defer closer.ErrorHandler(res.Body, &err)
-
-	return nil
+	_, err = s.client.RequestHelper(http.MethodDelete, fmt.Sprintf("/projects/%s/triggers/%s", projectID, triggerID), nil, nil)
+	return err
 }
 
 // Update The new trigger param can only have the esseential values:
 // name, description, event_preset, checkout_ref, config_ref
 // This are the only values that can be updated with this method
 func (s *TriggerService) Update(newTrigger Trigger, projectID, triggerID string) (_ *Trigger, err error) {
-	res, err := s.client.RequestHelper(http.MethodPatch, fmt.Sprintf("/projects/%s/triggers/%s", projectID, triggerID), newTrigger)
+	var trigger Trigger
+	_, err = s.client.RequestHelper(http.MethodPatch, fmt.Sprintf("/projects/%s/triggers/%s", projectID, triggerID), newTrigger, &trigger)
 	if err != nil {
 		return nil, err
 	}
-	defer closer.ErrorHandler(res.Body, &err)
-	var trigger Trigger
-	if err := json.NewDecoder(res.Body).Decode(&trigger); err != nil {
-		return nil, err
-	}
+
 	return &trigger, nil
 }


### PR DESCRIPTION
- This will shrink the responsibilities of the endpoint methods, making them easier and less verbose to write correctly.