### PR TITLE
Fix error while unmarshalling Tokens that are listed

### DIFF
--- a/internal/testing/fakecircle/runner.go
+++ b/internal/testing/fakecircle/runner.go
@@ -215,6 +215,10 @@ func (s *Service) listTokens(c *gin.Context) {
 		CreatedAt     string `json:"created_at"`
 	}
 
+	type responseItems struct {
+		Items []response `json:"items"`
+	}
+
 	filtered := make([]response, 0)
 	for _, t := range tokens {
 		if resourceClass == "" || t.ResourceClass == resourceClass {
@@ -227,7 +231,11 @@ func (s *Service) listTokens(c *gin.Context) {
 		}
 	}
 
-	c.JSON(http.StatusOK, filtered)
+	resp := responseItems{
+		Items: filtered,
+	}
+
+	c.JSON(http.StatusOK, resp)
 }
 
 func (s *Service) createToken(c *gin.Context) {

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -35,7 +35,7 @@ type ResourceClass struct {
 	Description   string `json:"description,omitempty"`
 }
 
-// ResourceClassItems represents a set of resource classes.
+// TokenItems represents a set of tokens.
 type TokenItems struct {
 	Items []Token `json:"items"`
 }

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -35,6 +35,11 @@ type ResourceClass struct {
 	Description   string `json:"description,omitempty"`
 }
 
+// ResourceClassItems represents a set of resource classes.
+type TokenItems struct {
+	Items []Token `json:"items"`
+}
+
 // Token represents a runner authentication token.
 type Token struct {
 	//nolint:revive
@@ -176,7 +181,7 @@ func (s *Service) DeleteResourceClass(ctx context.Context, id string, force bool
 }
 
 // ListTokens returns a list of tokens for a specific resource class.
-func (s *Service) ListTokens(ctx context.Context, resourceClass string) ([]Token, error) {
+func (s *Service) ListTokens(ctx context.Context, resourceClass string) (*TokenItems, error) {
 	values := url.Values{}
 	if resourceClass != "" {
 		values.Add("resource-class", resourceClass)
@@ -187,13 +192,13 @@ func (s *Service) ListTokens(ctx context.Context, resourceClass string) ([]Token
 		query = "?" + values.Encode()
 	}
 
-	var tokens []Token
+	var tokens TokenItems
 	_, err := s.client.RequestHelperAbsolute(ctx, http.MethodGet, s.baseURL+"/api/v3/runner/token"+query, nil, &tokens)
 	if err != nil {
 		return nil, err
 	}
 
-	return tokens, nil
+	return &tokens, nil
 }
 
 // CreateToken creates a new runner token.

--- a/runner/runner_test.go
+++ b/runner/runner_test.go
@@ -70,7 +70,8 @@ func TestFullRunner(t *testing.T) {
 	// List tokens
 	tokens, err := service.ListTokens(ctx, createReq.ResourceClass)
 	assert.NilError(t, err)
-	assert.Check(t, len(tokens) > 0)
+	assert.Check(t, tokens.Items != nil)
+	assert.Check(t, len(tokens.Items) > 0)
 
 	// Delete token
 	err = service.DeleteToken(ctx, tokenID)


### PR DESCRIPTION
# Description
Refactored `ListTokens` to return a `TokenItems` struct containing an `Items` slice, rather than a raw slice of tokens. This update includes the necessary changes to the SDK, the `fakecircle` mock service, and the test suite.

# Reasons
* **API Schema Alignment:** Similar to the Resource Class collection endpoint, the `ListTokens` GET endpoint returns a wrapped JSON object (`{"items": [...]}`). This change ensures the SDK can correctly parse these responses.
* **Consistency:** Brings the Token listing logic in line with the recently updated `ListResourceClasses` pattern, providing a consistent developer experience across the SDK.
* **Mock Accuracy:** Updated the `fakecircle` internal service to properly wrap token lists in a `responseItems` struct to prevent integration test failures.
