### PR TITLE
feat: add Schedule type and Parameters field for schedule trigger support [sc-2438]

### DIFF
--- a/common/models.go
+++ b/common/models.go
@@ -24,10 +24,16 @@ type CheckoutSource struct {
 	Repo     Repo   `json:"repo,omitzero"`
 }
 
+type Schedule struct {
+	CronExpression   string `json:"cron_expression,omitempty"`
+	AttributionActor string `json:"attribution_actor,omitempty"`
+}
+
 type EventSource struct {
-	Provider string  `json:"provider,omitempty"`
-	Repo     Repo    `json:"repo,omitzero"`
-	Webhook  Webhook `json:"webhook,omitzero"`
+	Provider string   `json:"provider,omitempty"`
+	Repo     Repo     `json:"repo,omitzero"`
+	Webhook  Webhook  `json:"webhook,omitzero"`
+	Schedule Schedule `json:"schedule,omitzero"`
 }
 
 type PaginatedResponse[T any] struct {

--- a/common/models.go
+++ b/common/models.go
@@ -26,7 +26,7 @@ type CheckoutSource struct {
 
 type Schedule struct {
 	CronExpression   string `json:"cron_expression,omitempty"`
-	AttributionActor string `json:"attribution_actor,omitempty"`
+	AttributionActor any    `json:"attribution_actor,omitempty"`
 }
 
 type EventSource struct {

--- a/trigger/trigger.go
+++ b/trigger/trigger.go
@@ -18,6 +18,7 @@ type Trigger struct {
 	EventName   string             `json:"event_name,omitempty"`
 	EventPreset string             `json:"event_preset,omitempty"`
 	Disabled    *bool              `json:"disabled,omitempty"`
+	Parameters  map[string]any     `json:"parameters,omitempty"`
 }
 
 // nolint:revive // introduced before linter

--- a/trigger/trigger_test.go
+++ b/trigger/trigger_test.go
@@ -12,8 +12,9 @@ import (
 )
 
 const (
-	knownPipelineID = "bee796a0-7ec2-478c-ab87-6a5039d7a216"
-	knownProjectID  = "e2e8ae23-57dc-4e95-bc67-633fdeb4ac33"
+	knownPipelineID         = "bee796a0-7ec2-478c-ab87-6a5039d7a216"
+	knownProjectID          = "e2e8ae23-57dc-4e95-bc67-633fdeb4ac33"
+	knownSchedulePipelineID = "FILL_IN_PIPELINE_DEFINITION_ID_THAT_SUPPORTS_SCHEDULE_TRIGGERS"
 )
 
 func TestListTrigger(t *testing.T) {
@@ -70,6 +71,51 @@ func TestFullTriggerNew(t *testing.T) {
 	triggerFetched, err = triggerService.Get(ctx, projectID, idNewTrigger)
 	assert.Assert(t, err != nil)
 	assert.Check(t, cmp.Nil(triggerFetched))
+}
+
+func TestFullScheduleTrigger(t *testing.T) {
+	ctx := context.TODO()
+	c := integrationtest.Client(t)
+	triggerService := NewTriggerService(c)
+
+	newTrigger := Trigger{
+		EventName:   "Test schedule trigger",
+		CheckoutRef: "main",
+		ConfigRef:   "main",
+		Disabled:    common.Bool(false),
+		EventSource: common.EventSource{
+			Provider: "schedule",
+			Schedule: common.Schedule{
+				CronExpression:   "0 1 * * *",
+				AttributionActor: "current",
+			},
+		},
+		Parameters: map[string]any{"env": "staging"},
+	}
+
+	created, err := triggerService.Create(ctx, newTrigger, knownProjectID, knownSchedulePipelineID)
+	assert.Assert(t, err)
+	assert.Check(t, created.ID != "")
+	assert.Check(t, cmp.Equal(created.EventSource.Provider, "schedule"))
+
+	fetched, err := triggerService.Get(ctx, knownProjectID, created.ID)
+	assert.Assert(t, err)
+	assert.Check(t, cmp.Equal(fetched.EventSource.Schedule.CronExpression, "0 1 * * *"))
+
+	_, err = triggerService.Update(ctx, Trigger{
+		EventName: "Updated schedule trigger",
+		EventSource: common.EventSource{
+			Schedule: common.Schedule{CronExpression: "0 2 * * *"},
+		},
+	}, knownProjectID, created.ID)
+	assert.Assert(t, err)
+
+	err = triggerService.Delete(ctx, knownProjectID, created.ID)
+	assert.Assert(t, err)
+
+	deleted, err := triggerService.Get(ctx, knownProjectID, created.ID)
+	assert.Assert(t, err != nil)
+	assert.Check(t, cmp.Nil(deleted))
 }
 
 func TestFullTrigger(t *testing.T) {

--- a/trigger/trigger_test.go
+++ b/trigger/trigger_test.go
@@ -14,7 +14,7 @@ import (
 const (
 	knownPipelineID         = "bee796a0-7ec2-478c-ab87-6a5039d7a216"
 	knownProjectID          = "e2e8ae23-57dc-4e95-bc67-633fdeb4ac33"
-	knownSchedulePipelineID = "fefb451c-9966-4b75-b555-d4d94d7116ef"
+	knownSchedulePipelineID = "bee796a0-7ec2-478c-ab87-6a5039d7a216"
 )
 
 func TestListTrigger(t *testing.T) {

--- a/trigger/trigger_test.go
+++ b/trigger/trigger_test.go
@@ -14,7 +14,7 @@ import (
 const (
 	knownPipelineID         = "bee796a0-7ec2-478c-ab87-6a5039d7a216"
 	knownProjectID          = "e2e8ae23-57dc-4e95-bc67-633fdeb4ac33"
-	knownSchedulePipelineID = "FILL_IN_PIPELINE_DEFINITION_ID_THAT_SUPPORTS_SCHEDULE_TRIGGERS"
+	knownSchedulePipelineID = "fefb451c-9966-4b75-b555-d4d94d7116ef"
 )
 
 func TestListTrigger(t *testing.T) {


### PR DESCRIPTION
## Summary

Adds the SDK types required to support schedule triggers in the CircleCI Terraform provider ([sc-2438]).

**Changes:**
- `common/models.go`: new `Schedule` struct (`cron_expression`, `attribution_actor`); `Schedule` field added to `EventSource`
- `trigger/trigger.go`: `Parameters map[string]any` field added to `Trigger`
- `trigger/trigger_test.go`: `TestFullScheduleTrigger` integration test (pipeline definition ID placeholder needs to be filled in before running)

This is a prerequisite for the provider change: CircleCI-Public/terraform-provider-circleci#sc-2438.

> **Note:** This PR is a draft opened as a starting point. Feel free to discard and reimplement from scratch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)