### PR TITLE
Scheduled triggers

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -92,7 +92,6 @@ func (c *Client) request(ctx context.Context, url, method string, body, respBody
 		}
 
 		// Pass the byte slice to Unmarshal instead of the Reader to Decoder
-		fmt.Printf("respBody type : %T\n", respBody)
 		if err := json.Unmarshal(b, respBody); err != nil {
 			return nil, errors.Wrapf(err, "error decoding response body: %s", string(b))
 		}

--- a/client/client.go
+++ b/client/client.go
@@ -92,6 +92,7 @@ func (c *Client) request(ctx context.Context, url, method string, body, respBody
 		}
 
 		// Pass the byte slice to Unmarshal instead of the Reader to Decoder
+		fmt.Printf("respBody type : %T\n", respBody)
 		if err := json.Unmarshal(b, respBody); err != nil {
 			return nil, errors.Wrapf(err, "error decoding response body: %s", string(b))
 		}

--- a/common/models.go
+++ b/common/models.go
@@ -24,10 +24,32 @@ type CheckoutSource struct {
 	Repo     Repo   `json:"repo,omitzero"`
 }
 
+type Schedule struct {
+	CronExpression   string `json:"cron_expression"`
+	AttributionActor string `json:"attribution_actor"`
+}
+
+type ScheduleResponse struct {
+	CronExpression   string                   `json:"cron_expression"`
+	AttributionActor AttributionActorResponse `json:"attribution_actor"`
+}
+
+type AttributionActorResponse struct {
+	Id string `json:"id"`
+}
+
 type EventSource struct {
+	Provider string   `json:"provider,omitempty"`
+	Repo     Repo     `json:"repo,omitzero"`
+	Webhook  Webhook  `json:"webhook,omitzero"`
+	Schedule Schedule `json:"schedule,omitzero"`
+}
+
+type EventSourceResponse struct {
 	Provider string  `json:"provider,omitempty"`
 	Repo     Repo    `json:"repo,omitzero"`
 	Webhook  Webhook `json:"webhook,omitzero"`
+	//Schedule ScheduleResponse `json:"schedule,omitzero"`
 }
 
 type PaginatedResponse[T any] struct {

--- a/common/models.go
+++ b/common/models.go
@@ -46,10 +46,10 @@ type EventSource struct {
 }
 
 type EventSourceResponse struct {
-	Provider string  `json:"provider,omitempty"`
-	Repo     Repo    `json:"repo,omitzero"`
-	Webhook  Webhook `json:"webhook,omitzero"`
-	//Schedule ScheduleResponse `json:"schedule,omitzero"`
+	Provider string           `json:"provider,omitempty"`
+	Repo     Repo             `json:"repo,omitzero"`
+	Webhook  Webhook          `json:"webhook,omitzero"`
+	Schedule ScheduleResponse `json:"schedule,omitzero"`
 }
 
 type PaginatedResponse[T any] struct {

--- a/trigger/trigger.go
+++ b/trigger/trigger.go
@@ -18,6 +18,19 @@ type Trigger struct {
 	EventName   string             `json:"event_name,omitempty"`
 	EventPreset string             `json:"event_preset,omitempty"`
 	Disabled    *bool              `json:"disabled,omitempty"`
+	Parameters  map[string]string  `json:"parameters,omitempty"`
+}
+
+type TriggerResponse struct {
+	ID          string                     `json:"id,omitempty"`
+	CreatedAt   string                     `json:"created_at,omitempty"`
+	CheckoutRef string                     `json:"checkout_ref,omitempty"`
+	ConfigRef   string                     `json:"config_ref,omitempty"`
+	EventSource common.EventSourceResponse `json:"event_source,omitzero"`
+	EventName   string                     `json:"event_name,omitempty"`
+	EventPreset string                     `json:"event_preset,omitempty"`
+	Disabled    *bool                      `json:"disabled,omitempty"`
+	Parameters  map[string]string          `json:"parameters,omitempty"`
 }
 
 // nolint:revive // introduced before linter
@@ -34,8 +47,8 @@ func NewTriggerService(c *client.Client) *TriggerService {
 	return &TriggerService{client: c}
 }
 
-func (s *TriggerService) Get(ctx context.Context, projectID, triggerID string) (_ *Trigger, err error) {
-	var trigger Trigger
+func (s *TriggerService) Get(ctx context.Context, projectID, triggerID string) (_ *TriggerResponse, err error) {
+	var trigger TriggerResponse
 	_, err = s.client.RequestHelper(ctx, http.MethodGet, fmt.Sprintf("/projects/%s/triggers/%s", projectID, triggerID), nil, &trigger)
 	if err != nil {
 		return nil, err
@@ -54,14 +67,14 @@ func (s *TriggerService) List(ctx context.Context, projectID, pipelineID string)
 	return triggerItems.Items, nil
 }
 
-func (s *TriggerService) Create(ctx context.Context, newTrigger Trigger, projectID, pipelineID string) (_ *Trigger, err error) {
-	var trigger Trigger
-	_, err = s.client.RequestHelper(ctx, http.MethodPost, fmt.Sprintf("/projects/%s/pipeline-definitions/%s/triggers", projectID, pipelineID), newTrigger, &trigger)
+func (s *TriggerService) Create(ctx context.Context, newTrigger Trigger, projectID, pipelineID string) (_ *TriggerResponse, err error) {
+	var triggerResponse TriggerResponse
+	_, err = s.client.RequestHelper(ctx, http.MethodPost, fmt.Sprintf("/projects/%s/pipeline-definitions/%s/triggers", projectID, pipelineID), newTrigger, &triggerResponse)
 	if err != nil {
 		return nil, err
 	}
 
-	return &trigger, nil
+	return &triggerResponse, nil
 }
 
 func (s *TriggerService) Delete(ctx context.Context, projectID, triggerID string) (err error) {
@@ -72,8 +85,8 @@ func (s *TriggerService) Delete(ctx context.Context, projectID, triggerID string
 // Update The new trigger param can only have the esseential values:
 // name, description, event_preset, checkout_ref, config_ref, disabled
 // This are the only values that can be updated with this method
-func (s *TriggerService) Update(ctx context.Context, newTrigger Trigger, projectID, triggerID string) (_ *Trigger, err error) {
-	var trigger Trigger
+func (s *TriggerService) Update(ctx context.Context, newTrigger Trigger, projectID, triggerID string) (_ *TriggerResponse, err error) {
+	var trigger TriggerResponse
 	_, err = s.client.RequestHelper(ctx, http.MethodPatch, fmt.Sprintf("/projects/%s/triggers/%s", projectID, triggerID), newTrigger, &trigger)
 	if err != nil {
 		return nil, err

--- a/trigger/trigger.go
+++ b/trigger/trigger.go
@@ -39,6 +39,7 @@ type TriggerItems struct {
 	Items []Trigger `json:"items"`
 }
 
+// nolint:revive // introduced before linter
 type TriggerResponseItems struct {
 	Items []TriggerResponse `json:"items"`
 }

--- a/trigger/trigger.go
+++ b/trigger/trigger.go
@@ -21,6 +21,7 @@ type Trigger struct {
 	Parameters  map[string]string  `json:"parameters,omitempty"`
 }
 
+// nolint:revive // introduced before linter
 type TriggerResponse struct {
 	ID          string                     `json:"id,omitempty"`
 	CreatedAt   string                     `json:"created_at,omitempty"`
@@ -36,6 +37,10 @@ type TriggerResponse struct {
 // nolint:revive // introduced before linter
 type TriggerItems struct {
 	Items []Trigger `json:"items"`
+}
+
+type TriggerResponseItems struct {
+	Items []TriggerResponse `json:"items"`
 }
 
 // nolint:revive // introduced before linter
@@ -57,14 +62,14 @@ func (s *TriggerService) Get(ctx context.Context, projectID, triggerID string) (
 	return &trigger, nil
 }
 
-func (s *TriggerService) List(ctx context.Context, projectID, pipelineID string) (_ []Trigger, err error) {
-	var triggerItems TriggerItems
-	_, err = s.client.RequestHelper(ctx, http.MethodGet, fmt.Sprintf("/projects/%s/pipeline-definitions/%s/triggers", projectID, pipelineID), nil, &triggerItems)
+func (s *TriggerService) List(ctx context.Context, projectID, pipelineID string) (_ []TriggerResponse, err error) {
+	var triggerResponseItems TriggerResponseItems
+	_, err = s.client.RequestHelper(ctx, http.MethodGet, fmt.Sprintf("/projects/%s/pipeline-definitions/%s/triggers", projectID, pipelineID), nil, &triggerResponseItems)
 	if err != nil {
 		return nil, err
 	}
 
-	return triggerItems.Items, nil
+	return triggerResponseItems.Items, nil
 }
 
 func (s *TriggerService) Create(ctx context.Context, newTrigger Trigger, projectID, pipelineID string) (_ *TriggerResponse, err error) {

--- a/trigger/trigger_test.go
+++ b/trigger/trigger_test.go
@@ -21,10 +21,8 @@ func TestListTrigger(t *testing.T) {
 	c := integrationtest.Client(t)
 	triggerService := NewTriggerService(c)
 
-	trs, err := triggerService.List(ctx, knownProjectID, knownPipelineID)
+	_, err := triggerService.List(ctx, knownProjectID, knownPipelineID)
 	assert.Assert(t, err)
-
-	t.Log(trs)
 }
 
 func TestFullTriggerNew(t *testing.T) {
@@ -62,7 +60,6 @@ func TestFullTriggerNew(t *testing.T) {
 
 	triggerFetched, err := triggerService.Get(ctx, projectID, idNewTrigger)
 	assert.Assert(t, err)
-	t.Log(triggerFetched)
 
 	err = triggerService.Delete(ctx, projectID, idNewTrigger)
 	assert.Assert(t, err)
@@ -105,7 +102,52 @@ func TestFullTrigger(t *testing.T) {
 	triggerFetched, err := triggerService.Get(ctx, projectID, idNewTrigger)
 	assert.Assert(t, err)
 
-	t.Log(triggerFetched)
+	err = triggerService.Delete(ctx, projectID, idNewTrigger)
+	assert.Assert(t, err)
+
+	triggerFetched, err = triggerService.Get(ctx, projectID, idNewTrigger)
+	assert.Assert(t, err != nil)
+	assert.Check(t, cmp.Nil(triggerFetched))
+}
+
+func TestFullScheduledTrigger(t *testing.T) {
+	ctx := context.TODO()
+	c := integrationtest.Client(t)
+	triggerService := NewTriggerService(c)
+
+	pipelineID := "bee796a0-7ec2-478c-ab87-6a5039d7a216"
+	projectID := "e2e8ae23-57dc-4e95-bc67-633fdeb4ac33"
+	newTrigger := Trigger{
+		EventSource: common.EventSource{
+			Provider: "schedule",
+			Repo: common.Repo{
+				ExternalId: "952038793",
+			},
+			Schedule: common.Schedule{
+				CronExpression:   "*/5 * * * *",
+				AttributionActor: "current",
+			},
+		},
+		EventName:   "test_schedule",
+		ConfigRef:   "main",
+		CheckoutRef: "main",
+		Disabled:    common.Bool(false),
+		Parameters:  map[string]string{"name": "david"},
+	}
+	triggerCreated, err := triggerService.Create(ctx, newTrigger, projectID, pipelineID)
+	assert.Assert(t, err)
+
+	idNewTrigger := triggerCreated.ID
+	triggerToUpdate := Trigger{
+		Disabled: common.Bool(true),
+	}
+
+	_, err = triggerService.Update(ctx, triggerToUpdate, projectID, idNewTrigger)
+	assert.Assert(t, err)
+
+	triggerFetched, err := triggerService.Get(ctx, projectID, idNewTrigger)
+	assert.Assert(t, err)
+
 	err = triggerService.Delete(ctx, projectID, idNewTrigger)
 	assert.Assert(t, err)
 

--- a/trigger/trigger_test.go
+++ b/trigger/trigger_test.go
@@ -58,13 +58,13 @@ func TestFullTriggerNew(t *testing.T) {
 	assert.Assert(t, err)
 	assert.Check(t, cmp.Equal(triggerUpdated.EventName, "New event name"))
 
-	triggerFetched, err := triggerService.Get(ctx, projectID, idNewTrigger)
+	_, err = triggerService.Get(ctx, projectID, idNewTrigger)
 	assert.Assert(t, err)
 
 	err = triggerService.Delete(ctx, projectID, idNewTrigger)
 	assert.Assert(t, err)
 
-	triggerFetched, err = triggerService.Get(ctx, projectID, idNewTrigger)
+	triggerFetched, err := triggerService.Get(ctx, projectID, idNewTrigger)
 	assert.Assert(t, err != nil)
 	assert.Check(t, cmp.Nil(triggerFetched))
 }
@@ -99,13 +99,13 @@ func TestFullTrigger(t *testing.T) {
 	_, err = triggerService.Update(ctx, triggerToUpdate, projectID, idNewTrigger)
 	assert.Assert(t, err)
 
-	triggerFetched, err := triggerService.Get(ctx, projectID, idNewTrigger)
+	_, err = triggerService.Get(ctx, projectID, idNewTrigger)
 	assert.Assert(t, err)
 
 	err = triggerService.Delete(ctx, projectID, idNewTrigger)
 	assert.Assert(t, err)
 
-	triggerFetched, err = triggerService.Get(ctx, projectID, idNewTrigger)
+	triggerFetched, err := triggerService.Get(ctx, projectID, idNewTrigger)
 	assert.Assert(t, err != nil)
 	assert.Check(t, cmp.Nil(triggerFetched))
 }
@@ -145,13 +145,13 @@ func TestFullScheduledTrigger(t *testing.T) {
 	_, err = triggerService.Update(ctx, triggerToUpdate, projectID, idNewTrigger)
 	assert.Assert(t, err)
 
-	triggerFetched, err := triggerService.Get(ctx, projectID, idNewTrigger)
+	_, err = triggerService.Get(ctx, projectID, idNewTrigger)
 	assert.Assert(t, err)
 
 	err = triggerService.Delete(ctx, projectID, idNewTrigger)
 	assert.Assert(t, err)
 
-	triggerFetched, err = triggerService.Get(ctx, projectID, idNewTrigger)
+	triggerFetched, err := triggerService.Get(ctx, projectID, idNewTrigger)
 	assert.Assert(t, err != nil)
 	assert.Check(t, cmp.Nil(triggerFetched))
 }


### PR DESCRIPTION
## PR Description: Support for Scheduled Triggers and Response Model Refactoring

### Overview
This PR introduces support for **Scheduled Triggers** and refactors the trigger response handling logic. It separates the internal `Trigger` structure (used for creation/updates) from the `TriggerResponse` structure (used for unmarshalling API responses). This specifically addresses type mismatches when unmarshalling nested objects like `attribution_actor`.

---

### Key Changes

#### 1. Models & Common Types
* **Introduced `TriggerResponse`**: A new struct dedicated to handling API responses, ensuring fields like `created_at` and nested `event_source` are correctly captured.
* **Resolved Type Mismatches**: 
    * Added `ScheduleResponse` and `AttributionActorResponse`.
    * Updated `EventSourceResponse` to use `ScheduleResponse`, allowing the `attribution_actor` to be unmarshalled as an object (containing an `id`) rather than a simple string.
* **Added `Parameters`**: Included support for the `parameters` map in both trigger models.

#### 2. Service Layer
* Updated `TriggerService` methods (`Get`, `List`, `Create`, `Update`) to return `TriggerResponse` instead of the base `Trigger` struct.
* Modified `TriggerItems` to `TriggerResponseItems` to handle paginated or list-based responses with the new model.

#### 3. Client & Debugging
* Added temporary `fmt.Printf` in `client/client.go` to log the type of `respBody` during unmarshalling to verify correct struct pointer passing.

#### 4. Testing
* **New Test Case**: Added `TestFullScheduledTrigger` in `trigger_test.go` to validate the end-to-end flow of creating, updating, and deleting a trigger with a `schedule` provider.
* Cleaned up test logs and improved assertion checks for deleted triggers.

---

### How to Test
1.  Run the integration tests:
    ```bash
    go test -v ./trigger/...
    ```
2.  Verify that the `TestFullScheduledTrigger` passes, confirming that the JSON response with a nested `attribution_actor` object no longer causes unmarshal errors.
