### PR TITLE
fix: use org name from project slug instead of user.Login in follow URL

### DIFF
--- a/project/project.go
+++ b/project/project.go
@@ -70,14 +70,9 @@ func (s *ProjectService) Create(ctx context.Context, projectName, organizationID
 
 	slug := strings.Split(project.Slug, "/")
 	if len(slug) == 3 && slug[1] == project.OrganizationName {
-		// TODO: The URL here probably need to be used in a different way depending on how on premise works
-		var user common.User
-		_, err = s.client.RequestHelperAbsolute(ctx, http.MethodGet, "https://circleci.com/api/v1.1/me", nil, &user)
-		if err != nil {
-			return nil, err
-		}
-		// TODO: The URL here probably need to be used in a different way depending on how on premise works
-		url := fmt.Sprintf("https://circleci.com/api/v1.1/project/%s/%s/%s/follow", strings.ToLower(project.VcsInfo.Provider), user.Login, project.Name)
+		orgName := slug[1]
+		// TODO: The URL here probably needs to be derived from the configured host for on-premise support
+		url := fmt.Sprintf("https://circleci.com/api/v1.1/project/%s/%s/%s/follow", strings.ToLower(project.VcsInfo.Provider), orgName, project.Name)
 		_, err = s.client.RequestHelperAbsolute(ctx, http.MethodPost, url, nil, nil)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
## Summary

- Fixes https://github.com/CircleCI-Public/terraform-provider-circleci/issues/102: `ProjectService.Create` was calling `/api/v1.1/me` to get the token owner's username and using it in the v1.1 follow URL. This caused 404 errors when the API token belonged to a user whose personal username differed from the organization name (which is the common case for org-owned repositories).
- The fix uses `slug[1]` the org name already available from the project's slug (e.g., `github/org-name/repo-name`) eliminating the unnecessary `/me` API call entirely.

## What changed

```diff
-    var user common.User
-    _, err = s.client.RequestHelperAbsolute(ctx, http.MethodGet, "https://circleci.com/api/v1.1/me", nil, &user)
-    if err != nil { return nil, err }
-    url := fmt.Sprintf(".../%s/%s/%s/follow", ..., user.Login, project.Name)
+    orgName := slug[1]
+    url := fmt.Sprintf(".../%s/%s/%s/follow", ..., orgName, project.Name)
```

## Test plan

- [x] Existing unit tests pass (`go test ./project/ -v`)
- [x] `go build ./...` passes
- [ ] Manual verification: create a project via Terraform for an org where token owner != org name
